### PR TITLE
Fix llama-cpp-version to 0.1.78 to support GGML3

### DIFF
--- a/13B_BlueMethod.ipynb
+++ b/13B_BlueMethod.ipynb
@@ -3,8 +3,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/Troyanovsky/Local-LLM-comparison/blob/main/13B_BlueMethod.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -44,8 +44,8 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "/content\n",
             "Selecting previously unselected package libc-ares2:amd64.\n",
@@ -367,7 +367,6 @@
           ]
         },
         {
-          "output_type": "display_data",
           "data": {
             "application/vnd.colab-display-data+json": {
               "pip_warning": {
@@ -377,11 +376,12 @@
               }
             }
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Collecting gradio==3.32.0\n",
             "  Downloading gradio-3.32.0-py3-none-any.whl (19.9 MB)\n",
@@ -720,7 +720,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/13B-BlueMethod-GGML/resolve/main/13b-bluemethod.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o 13b-bluemethod.ggmlv3.q5_K_M.bin\n",
         "\n",
@@ -732,9 +732,9 @@
   "metadata": {
     "accelerator": "GPU",
     "colab": {
-      "provenance": [],
       "authorship_tag": "ABX9TyOJl75GURDW2ava57XHeTem",
-      "include_colab_link": true
+      "include_colab_link": true,
+      "provenance": []
     },
     "gpuClass": "standard",
     "kernelspec": {

--- a/13B_Ouroboros.ipynb
+++ b/13B_Ouroboros.ipynb
@@ -3,8 +3,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/Troyanovsky/Local-LLM-Comparison-Colab-UI/blob/main/13B_Ouroboros.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -44,8 +44,8 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "/content\n",
             "Selecting previously unselected package libc-ares2:amd64.\n",
@@ -365,7 +365,6 @@
           ]
         },
         {
-          "output_type": "display_data",
           "data": {
             "application/vnd.colab-display-data+json": {
               "pip_warning": {
@@ -375,11 +374,12 @@
               }
             }
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Collecting gradio==3.32.0\n",
             "  Downloading gradio-3.32.0-py3-none-any.whl (19.9 MB)\n",
@@ -673,7 +673,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/13B-Ouroboros-GGML/resolve/main/13b-ouroboros.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o 13b-ouroboros.ggmlv3.q5_K_M.bin\n",
         "\n",
@@ -685,9 +685,9 @@
   "metadata": {
     "accelerator": "GPU",
     "colab": {
-      "provenance": [],
       "authorship_tag": "ABX9TyNOR/ngj5ScqyMK31UQsSAm",
-      "include_colab_link": true
+      "include_colab_link": true,
+      "provenance": []
     },
     "gpuClass": "standard",
     "kernelspec": {

--- a/AlpacaCielo_13B.ipynb
+++ b/AlpacaCielo_13B.ipynb
@@ -664,7 +664,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/AlpacaCielo-13B-GGML/resolve/main/alpacacielo-13b.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o alpacacielo-13b.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/Camel_Platypus2_13B.ipynb
+++ b/Camel_Platypus2_13B.ipynb
@@ -683,7 +683,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/Camel-Platypus2-13B-GGML/resolve/main/camel-platypus2-13b.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o camel-platypus2-13b.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/Chronos_13B_v2.ipynb
+++ b/Chronos_13B_v2.ipynb
@@ -661,7 +661,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/Chronos-13B-v2-GGML/resolve/main/chronos-13b-v2.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o chronos-13b-v2.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/Chronos_Beluga_v2_13B.ipynb
+++ b/Chronos_Beluga_v2_13B.ipynb
@@ -661,7 +661,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/Chronos-Beluga-v2-13B-GGML/resolve/main/chronos-beluga-v2-13b.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o chronos-beluga-v2-13b.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/Chronos_Hermes_13B_v2.ipynb
+++ b/Chronos_Hermes_13B_v2.ipynb
@@ -661,7 +661,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/Chronos-Hermes-13B-v2-GGML/resolve/main/chronos-hermes-13b-v2.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o chronos-hermes-13b-v2.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/CodeUp_Alpha_13B_HF.ipynb
+++ b/CodeUp_Alpha_13B_HF.ipynb
@@ -597,7 +597,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/CodeUp-Alpha-13B-HF-GGML/resolve/main/codeup-alpha-13b-hf.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o codeup-alpha-13b-hf.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/CodeUp_Llama_2_13B_Chat_HF.ipynb
+++ b/CodeUp_Llama_2_13B_Chat_HF.ipynb
@@ -589,7 +589,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/CodeUp-Llama-2-13B-Chat-HF-GGML/resolve/main/codeup-llama-2-13b-chat-hf.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o codeup-llama-2-13b-chat-hf.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/Dolphin_Llama_13B.ipynb
+++ b/Dolphin_Llama_13B.ipynb
@@ -683,7 +683,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/Dolphin-Llama-13B-GGML/resolve/main/dolphin-llama-13b.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o dolphin-llama-13b.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/Huginn_13B.ipynb
+++ b/Huginn_13B.ipynb
@@ -676,7 +676,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/Huginn-13B-GGML/resolve/main/huggin-13b.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o huggin-13b.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/Kimiko_13B.ipynb
+++ b/Kimiko_13B.ipynb
@@ -681,7 +681,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/Kimiko-13B-GGML/resolve/main/kimiko-13b.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o kimiko-13b.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/Llama_2_13B_chat.ipynb
+++ b/Llama_2_13B_chat.ipynb
@@ -664,7 +664,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/Llama-2-13B-chat-GGML/resolve/main/llama-2-13b-chat.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o llama-2-13b-chat.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/Luna_AI_Llama2_Uncensored.ipynb
+++ b/Luna_AI_Llama2_Uncensored.ipynb
@@ -682,7 +682,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/Luna-AI-Llama2-Uncensored-GGML/resolve/main/luna-ai-llama2-uncensored.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o luna-ai-llama2-uncensored.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/MythoBoros_13B.ipynb
+++ b/MythoBoros_13B.ipynb
@@ -664,7 +664,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/MythoBoros-13B-GGML/resolve/main/mythoboros-13b.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o mythoboros-13b.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/MythoLogic_13B.ipynb
+++ b/MythoLogic_13B.ipynb
@@ -667,7 +667,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/MythoLogic-13B-GGML/resolve/main/mythologic-13b.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o mythologic-13b.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/Nous_Hermes_Llama2.ipynb
+++ b/Nous_Hermes_Llama2.ipynb
@@ -688,7 +688,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/Nous-Hermes-Llama2-GGML/resolve/main/nous-hermes-llama2-13b.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o nous-hermes-llama2-13b.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/OpenChat_v3_2.ipynb
+++ b/OpenChat_v3_2.ipynb
@@ -570,7 +570,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/OpenChat_v3.2-GGML/resolve/main/openchat_v3.2.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o openchat_v3.2.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/OpenOrca_Platypus2_13B.ipynb
+++ b/OpenOrca_Platypus2_13B.ipynb
@@ -682,7 +682,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/OpenOrca-Platypus2-13B-GGML/resolve/main/openorca-platypus2-13b.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o openorca-platypus2-13b.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/Platypus2_13B.ipynb
+++ b/Platypus2_13B.ipynb
@@ -683,7 +683,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/Platypus2-13B-GGML/resolve/main/platypus2-13b.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o platypus2-13b.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/Redmond_Puffin_13B.ipynb
+++ b/Redmond_Puffin_13B.ipynb
@@ -664,7 +664,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/Redmond-Puffin-13B-GGML/resolve/main/redmond-puffin-13b.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o redmond-puffin-13b.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/StableBeluga_13B.ipynb
+++ b/StableBeluga_13B.ipynb
@@ -672,7 +672,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/StableBeluga-13B-GGML/resolve/main/stablebeluga-13b.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o stablebeluga-13b.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/Stable_Platypus2_13B.ipynb
+++ b/Stable_Platypus2_13B.ipynb
@@ -683,7 +683,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/Stable-Platypus2-13B-GGML/resolve/main/stable-platypus2-13b.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o stable-platypus2-13b.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/WizardLM_13B_V1_1_GGML.ipynb
+++ b/WizardLM_13B_V1_1_GGML.ipynb
@@ -670,7 +670,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/WizardLM-13B-V1.1-GGML/resolve/main/wizardlm-13b-v1.1.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o wizardlm-13b-v1.1.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/WizardLM_13B_V1_2.ipynb
+++ b/WizardLM_13B_V1_2.ipynb
@@ -670,7 +670,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/WizardLM-13B-V1.2-GGML/resolve/main/wizardlm-13b-v1.2.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o wizardlm-13b-v1.2.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/WizardLM_1_0_Uncensored_Llama2_13B.ipynb
+++ b/WizardLM_1_0_Uncensored_Llama2_13B.ipynb
@@ -659,7 +659,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/WizardLM-1.0-Uncensored-Llama2-13B-GGML/resolve/main/wizardlm-1.0-uncensored-llama2-13b.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o wizardlm-1.0-uncensored-llama2-13b.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/airoboros_l2_13b_gpt4_2_0.ipynb
+++ b/airoboros_l2_13b_gpt4_2_0.ipynb
@@ -674,7 +674,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/airoboros-l2-13b-gpt4-2.0-GGML/resolve/main/airoboros-l2-13b-gpt4-2.0.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o airoboros-l2-13b-gpt4-2.0.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/baichuan_vicuna_7B_GGML.ipynb
+++ b/baichuan_vicuna_7B_GGML.ipynb
@@ -67,7 +67,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/baichuan-vicuna-7B-GGML/resolve/main/baichuan-vicuna-7b.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o baichuan-vicuna-7b.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/llama_13b_supercot_GGML.ipynb
+++ b/llama_13b_supercot_GGML.ipynb
@@ -561,7 +561,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/llama-13b-supercot-GGML/resolve/main/llama-13b-supercot.ggmlv3.q5_1.bin -d /content/text-generation-webui/models/ -o llama-13b-supercot.ggmlv3.q5_1.bin\n",
         "\n",

--- a/llama_2_13B_Guanaco_QLoRA.ipynb
+++ b/llama_2_13B_Guanaco_QLoRA.ipynb
@@ -683,7 +683,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/llama-2-13B-Guanaco-QLoRA-GGML/resolve/main/llama-2-13b-guanaco-qlora.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o llama-2-13b-guanaco-qlora.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/orca_mini_13b_ggmlv3_q5_K_M.ipynb
+++ b/orca_mini_13b_ggmlv3_q5_K_M.ipynb
@@ -645,7 +645,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/orca_mini_13B-GGML/resolve/main/orca-mini-13b.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o orca-mini-13b.ggmlv3.q5_K_M.bin\n",
         "\n",

--- a/vicuna_13B_v1_5.ipynb
+++ b/vicuna_13B_v1_5.ipynb
@@ -659,7 +659,7 @@
         "!pip install -U gradio==3.32.0\n",
         "\n",
         "!pip uninstall -y llama-cpp-python\n",
-        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python --no-cache-dir\n",
+        "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78 --no-cache-dir\n",
         "\n",
         "!aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/TheBloke/vicuna-13B-v1.5-GGML/resolve/main/vicuna-13b-v1.5.ggmlv3.q5_K_M.bin -d /content/text-generation-webui/models/ -o vicuna-13b-v1.5.ggmlv3.q5_K_M.bin\n",
         "\n",


### PR DESCRIPTION
Starting with llama-cpp-python version 0.1.79 the model format has changed from ggmlv3 to gguf. Old model files can be converted using the convert-llama-ggmlv3-to-gguf.py script in llama.cpp

Meanwhile, I suggest to fix the version to 0.1.78 for the notebooks to run